### PR TITLE
fix(BasePointerRenderer): handle destroyed origin transform follow

### DIFF
--- a/Assets/VRTK/Source/Scripts/Pointers/PointerRenderers/VRTK_BasePointerRenderer.cs
+++ b/Assets/VRTK/Source/Scripts/Pointers/PointerRenderers/VRTK_BasePointerRenderer.cs
@@ -153,7 +153,9 @@ namespace VRTK
         /// </summary>
         public virtual void ResetPointerObjects()
         {
+            DestroyPointerOriginTransformFollow();
             DestroyPointerObjects();
+            CreatePointerOriginTransformFollow();
             CreatePointerObjects();
         }
 
@@ -295,7 +297,7 @@ namespace VRTK
                 Destroy(objectInteractor);
             }
             controllerGrabScript = null;
-            Destroy(pointerOriginTransformFollowGameObject);
+            DestroyPointerOriginTransformFollow();
         }
 
         protected virtual void OnDestroy()
@@ -316,7 +318,10 @@ namespace VRTK
                 UpdateObjectInteractor();
             }
 
-            UpdatePointerOriginTransformFollow();
+            if (pointerOriginTransformFollow != null)
+            {
+                UpdatePointerOriginTransformFollow();
+            }
         }
 
         protected virtual void ToggleObjectInteraction(bool state)
@@ -608,6 +613,16 @@ namespace VRTK
             pointerOriginTransformFollow.enabled = false;
             pointerOriginTransformFollow.moment = VRTK_TransformFollow.FollowMoment.OnFixedUpdate;
             pointerOriginTransformFollow.followsScale = false;
+        }
+
+        protected virtual void DestroyPointerOriginTransformFollow()
+        {
+            if (pointerOriginTransformFollowGameObject != null)
+            {
+                Destroy(pointerOriginTransformFollowGameObject);
+                pointerOriginTransformFollowGameObject = null;
+                pointerOriginTransformFollow = null;
+            }
         }
 
         protected virtual float OverrideBeamLength(float currentLength)


### PR DESCRIPTION
Reset pointer origin transform follow on ResetPointerObjects.
Add null check in event of a destroyed pointer origin.