### PR TITLE
fix(Unity2018): reset main texture to null

### DIFF
--- a/Assets/VRTK/Source/Scripts/Interactions/Highlighters/VRTK_MaterialColorSwapHighlighter.cs
+++ b/Assets/VRTK/Source/Scripts/Interactions/Highlighters/VRTK_MaterialColorSwapHighlighter.cs
@@ -160,7 +160,7 @@ namespace VRTK.Highlighters
 
                     if (resetMainTexture && material.HasProperty("_MainTex"))
                     {
-                        renderer.material.SetTexture("_MainTex", new Texture());
+                        renderer.material.SetTexture("_MainTex", null);
                     }
 
                     if (material.HasProperty("_Color"))


### PR DESCRIPTION
Base class Texture constructor is now protected, use null instead